### PR TITLE
unified dependencies version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>chat-javafx-client</module>
         <module>metadata-context-example</module>
         <module>zipkin-prometheus-example</module>
+        <module>springboot</module>
         <!--
         <module>springboot</module>
         -->

--- a/springboot/eureka-server/src/main/resources/application.properties
+++ b/springboot/eureka-server/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-server.port=8761
-spring.application.name=Eureka Server
-eureka.client.registerWithEureka=false
-eureka.client.fetchRegistry=false
-eureka.client.server.waitTimeInMsWhenSyncEmpty=0

--- a/springboot/eureka-server/src/main/resources/application.yml
+++ b/springboot/eureka-server/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+server:
+  port: 8761
+spring:
+  application:
+    name: Eureka Server
+
+
+eureka:
+  server:
+    enableSelfPreservation: false
+  instance:
+    leaseRenewalIntervalInSeconds: 3
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+    server:
+      waitTimeInMsWhenSyncEmpty: 0

--- a/springboot/grpc-client/pom.xml
+++ b/springboot/grpc-client/pom.xml
@@ -27,16 +27,24 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>springboot-grpc-client</artifactId>
-
-
-    <properties>
-        <grpc.version>1.0.0</grpc.version>
-        <protoc.version>3.0.0-beta-2</protoc.version>
-        <protoc.plugin.version>0.5.0</protoc.plugin.version>
-    </properties>
-
-
+    
     <dependencies>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-eureka</artifactId>

--- a/springboot/grpc-client/pom.xml
+++ b/springboot/grpc-client/pom.xml
@@ -66,6 +66,23 @@
             <artifactId>grpc-client-starter</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-eureka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-feign</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/springboot/grpc-client/pom.xml
+++ b/springboot/grpc-client/pom.xml
@@ -27,6 +27,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>springboot-grpc-client</artifactId>
+
+
+    <properties>
+        <grpc.version>1.0.0</grpc.version>
+        <protoc.version>3.0.0-beta-2</protoc.version>
+        <protoc.plugin.version>0.5.0</protoc.plugin.version>
+    </properties>
+
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -43,25 +52,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>springboot-grpc-server</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-actuator</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-web</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.github.saturnism.springboot</groupId>
-                    <artifactId>grpc-server-starter</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.github.saturnism.springboot</groupId>
             <artifactId>grpc-client-starter</artifactId>
             <version>1.0.0-SNAPSHOT</version>
@@ -70,14 +60,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-eureka</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -92,5 +74,32 @@
                 <artifactId>os-maven-plugin</artifactId>
             </extension>
         </extensions>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.xolstice.maven.plugins</groupId>
+                    <artifactId>protobuf-maven-plugin</artifactId>
+                    <version>${protoc.plugin.version}</version>
+                    <configuration>
+                        <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                        <pluginId>grpc-java</pluginId>
+                        <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>compile</goal>
+                                <goal>compile-custom</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>kr.motd.maven</groupId>
+                    <artifactId>os-maven-plugin</artifactId>
+                    <version>${os.plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/springboot/grpc-client/src/main/java/com/example/grpc/springboot/Cmd.java
+++ b/springboot/grpc-client/src/main/java/com/example/grpc/springboot/Cmd.java
@@ -48,11 +48,11 @@ public class Cmd {
 	public void requestRegular() {
 		System.out.println("hello");
 		Channel channel = channelFactory.createChannel("EchoService");
-		discoveryClient.getServices();
+//		discoveryClient.getServices();
 
+    i++;
 		EchoServiceGrpc.EchoServiceBlockingStub stub = EchoServiceGrpc.newBlockingStub(channel);
 		EchoOuterClass.Echo response = stub.echo(EchoOuterClass.Echo.newBuilder().setMessage("Hello " + i).build());
 		System.out.println(response);
-		i++;
 	}
 }

--- a/springboot/grpc-client/src/main/java/com/example/grpc/springboot/Cmd.java
+++ b/springboot/grpc-client/src/main/java/com/example/grpc/springboot/Cmd.java
@@ -20,6 +20,7 @@ import com.example.echo.EchoOuterClass;
 import com.example.echo.EchoServiceGrpc;
 import io.grpc.Channel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.autoconfigure.grpc.client.GrpcChannelFactory;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
@@ -32,7 +33,7 @@ import org.springframework.stereotype.Component;
 @EnableDiscoveryClient
 public class Cmd {
   @Autowired
-  public Cmd(ApplicationArguments args, GrpcChannelFactory channelFactory) {
+  public Cmd(ApplicationArguments args, @Qualifier("discoveryClientChannelFactory") GrpcChannelFactory channelFactory) {
     System.out.println("hello");
 
     Channel channel = channelFactory.createChannel("EchoService");
@@ -45,7 +46,7 @@ public class Cmd {
       i++;
 
       try {
-        Thread.sleep(100L);
+        Thread.sleep(10_000L);
       } catch (InterruptedException e) {
       }
     }

--- a/springboot/grpc-client/src/main/java/com/example/grpc/springboot/GrpcClient.java
+++ b/springboot/grpc-client/src/main/java/com/example/grpc/springboot/GrpcClient.java
@@ -16,18 +16,14 @@
 
 package com.example.grpc.springboot;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
-import org.springframework.stereotype.Component;
 
 /**
  * Created by rayt on 5/18/16.
  */
 @SpringBootApplication
-@Component
 @EnableEurekaClient
 public class GrpcClient {
   public static void main(String[] args) {

--- a/springboot/grpc-client/src/main/proto/Echo.proto
+++ b/springboot/grpc-client/src/main/proto/Echo.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package com.example.echo;
+
+message Echo {
+  string message = 1;
+}
+
+service EchoService {
+  rpc echo(Echo) returns (Echo);
+}

--- a/springboot/grpc-client/src/main/resources/application.properties
+++ b/springboot/grpc-client/src/main/resources/application.properties
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+port=19001
+server.port=19000
 spring.application.name=grpc-client
+spring.main.web-environment=false
 
 grpc.client.channels.EchoService.discovery=true

--- a/springboot/grpc-client/src/main/resources/logback.xml
+++ b/springboot/grpc-client/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="6 seconds">
+
+	<property name="LOG_HOME" value="/data/weblog/tomcat/zbase.yyembed.yy.com" />
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<charset>UTF-8</charset>
+			<pattern>%date{yyyy-MM-dd HH:mm:ss} [%thread] %-5level [%file:%line] - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="WARN">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/springboot/grpc-server/pom.xml
+++ b/springboot/grpc-server/pom.xml
@@ -27,6 +27,22 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/springboot/grpc-server/src/main/java/com/example/grpc/springboot/EchoServiceImpl.java
+++ b/springboot/grpc-server/src/main/java/com/example/grpc/springboot/EchoServiceImpl.java
@@ -28,7 +28,7 @@ import org.springframework.boot.autoconfigure.grpc.server.GrpcService;
 public class EchoServiceImpl implements EchoServiceGrpc.EchoService {
   @Override
   public void echo(EchoOuterClass.Echo request, StreamObserver<EchoOuterClass.Echo> responseObserver) {
-    System.out.println(request);
+    System.out.println("#################################################################" + request);
     responseObserver.onNext(request);
     responseObserver.onCompleted();
   }

--- a/springboot/grpc-server/src/main/java/com/example/grpc/springboot/EchoServiceImpl.java
+++ b/springboot/grpc-server/src/main/java/com/example/grpc/springboot/EchoServiceImpl.java
@@ -25,9 +25,7 @@ import org.springframework.boot.autoconfigure.grpc.server.GrpcService;
  * Created by rayt on 5/18/16.
  */
 @GrpcService(EchoServiceGrpc.class)
-public class EchoServiceImpl implements EchoServiceGrpc.EchoService {
-
-
+public class EchoServiceImpl extends EchoServiceGrpc.EchoServiceImplBase {
 
   @Override
   public void echo(EchoOuterClass.Echo request, StreamObserver<EchoOuterClass.Echo> responseObserver) {

--- a/springboot/grpc-server/src/main/java/com/example/grpc/springboot/EchoServiceImpl.java
+++ b/springboot/grpc-server/src/main/java/com/example/grpc/springboot/EchoServiceImpl.java
@@ -26,9 +26,12 @@ import org.springframework.boot.autoconfigure.grpc.server.GrpcService;
  */
 @GrpcService(EchoServiceGrpc.class)
 public class EchoServiceImpl implements EchoServiceGrpc.EchoService {
+
+
+
   @Override
   public void echo(EchoOuterClass.Echo request, StreamObserver<EchoOuterClass.Echo> responseObserver) {
-    System.out.println("#################################################################" + request);
+    System.out.println("####################" + request + " port ");
     responseObserver.onNext(request);
     responseObserver.onCompleted();
   }

--- a/springboot/grpc-server/src/main/resources/application.properties
+++ b/springboot/grpc-server/src/main/resources/application.properties
@@ -1,3 +1,0 @@
-grpc.server.port=${server.port:9090}
-spring.application.name=EchoService
-eureka.instance.nonSecurePort=${server.port}

--- a/springboot/grpc-server/src/main/resources/application.yml
+++ b/springboot/grpc-server/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+port: 9000
+grpc:
+  server:
+    port: ${port}
+spring:
+  application:
+    name: EchoService
+server:
+  port: ${port}
+#eureka.instance.instanceId=instance-2
+#eureka.instance.nonSecurePort=${server.port:9091}
+#eureka.instance.nonSecurePort=${server.port}
+
+
+eureka:
+  instance:
+    nonSecurePort: ${port}
+    leaseRenewalIntervalInSeconds: 1
+    leaseExpirationDurationInSeconds: 2

--- a/springboot/grpc-server/src/main/resources/application.yml
+++ b/springboot/grpc-server/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-port: 9000
+port: 9004
 grpc:
   server:
     port: ${port}

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -2,28 +2,24 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>grpc-demos</artifactId>
-        <groupId>com.example</groupId>
-        <version>1.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
-    </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>com.example</groupId>
     <artifactId>springboot</artifactId>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
         <spring.boot.version>1.5.2.RELEASE</spring.boot.version>
         <spring.cloud.version>Dalston.RELEASE</spring.cloud.version>
         <grpc.version>1.0.0</grpc.version>
-        <protoc.version>3.0.0-beta-2</protoc.version>
+        <protoc.version>3.0.0</protoc.version>
         <protoc.plugin.version>0.5.0</protoc.plugin.version>
         <spring.boot.version>1.5.2.RELEASE</spring.boot.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <netty.version>1.1.33.Fork14</netty.version>
-        <grpc.version>1.0.0</grpc.version>
         <os.plugin.version>1.4.0.Final</os.plugin.version>
     </properties>
 

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -14,8 +14,17 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring.boot.version>1.3.5.RELEASE</spring.boot.version>
-        <spring.cloud.version>Brixton.RELEASE</spring.cloud.version>
+        <spring.boot.version>1.5.2.RELEASE</spring.boot.version>
+        <spring.cloud.version>Dalston.RELEASE</spring.cloud.version>
+        <grpc.version>1.0.0</grpc.version>
+        <protoc.version>3.0.0-beta-2</protoc.version>
+        <protoc.plugin.version>0.5.0</protoc.plugin.version>
+        <spring.boot.version>1.5.2.RELEASE</spring.boot.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <netty.version>1.1.33.Fork14</netty.version>
+        <grpc.version>1.0.0</grpc.version>
+        <os.plugin.version>1.4.0.Final</os.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -56,6 +65,32 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
+            </plugin>
+
+
+
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>${protoc.plugin.version}</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os.plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/springboot/pom.xml
+++ b/springboot/pom.xml
@@ -19,7 +19,7 @@
         <spring.boot.version>1.5.2.RELEASE</spring.boot.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <netty.version>1.1.33.Fork14</netty.version>
+        <netty.version>2.0.0.Final</netty.version>
         <os.plugin.version>1.4.0.Final</os.plugin.version>
     </properties>
 


### PR DESCRIPTION
Hi~~, 
I do changes a lot so that it can't easily merge. Just post it to tell your first.
It match my version of spring-boot-starter-grpc, which also post a pull request. They work well together.


When I try to upgrade to grpc 1.2.0, but there's something wrong with client.  
eureka and server is ok.

Here is the error stack.
2017-04-16 17:33:39 [pool-8-thread-1] ERROR [TaskUtils.java:95] - Unexpected error occurred in scheduled task.
io.grpc.StatusRuntimeException: UNAVAILABLE: Transport closed for unknown reason
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:227)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:208)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:141)
	at com.example.echo.EchoServiceGrpc$EchoServiceBlockingStub.echo(EchoServiceGrpc.java:135)
	at com.example.grpc.springboot.Cmd.requestRegular(Cmd.java:55)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:65)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)